### PR TITLE
Remove django-jsonfield dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ max-line-length = 120
 [isort]
 include_trailing_comma = True
 known_first_party = gargoyle,testapp
-known_third_party = django,jsonfield,modeldict,nexus,pytz
+known_third_party = django,modeldict,nexus,pytz
 line_length = 120
 multi_line_output = 5
 not_skip = __init__.py

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,9 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     zip_safe=False,
     install_requires=[
-        'Django>=1.11',
+        'Django>=3.2',
         'django-modeldict-yplan>=2.0.0',
         'nexus-yplan>=2.1.0',
-        'django-jsonfield>=1.2.0',
     ],
     python_requires='>=3.4',
     license='Apache License 2.0',


### PR DESCRIPTION
The django-jsonfield dependency is no longer in use, and is no longer required.

- [x] Verify that all `tox` unit tests pass without issue.